### PR TITLE
Add dark mode to documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ MANIFEST
 *.manifest
 *.spec
 .idea/
+
+# extra for documantation builds
+docs/_build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,8 +33,11 @@ author = 'Emmanuel Obara'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx_rtd_theme'
+    'sphinx_rtd_theme',
+    'sphinx_rtd_dark_mode',
 ]
+
+default_dark_mode = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
 Sphinx==8.1.3
 sphinx-rtd-theme==3.0.2
+pillow==11.0.0
+python-tkdnd==0.2.0
+sphinx-rtd-dark-mode==1.3.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
 Sphinx==8.1.3
 sphinx-rtd-theme==3.0.2
-pillow==11.0.0
-python-tkdnd==0.2.0
 sphinx-rtd-dark-mode==1.3.0


### PR DESCRIPTION
There were following modules missing;

- pillow
- python-tkdnd

Also i wanted to add dark mode. There were no change on the initial theme. I have found a dark mode for the exact same theme!

[sphinx-rtd-dark-mode](https://pypi.org/project/sphinx-rtd-dark-mode/)

And added
`docs/_build`
to .gitignore since we do not want builds on repo.

I really liked your project btw. 😃