### PR TITLE
[DOCS] removes comma from ubuntu installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Formation Studio uses TKinter and, depending on the distribution/platform, it ma
 Install command for `tkinter` and `imagetk` on Debian Python:
 
 ```bash
-sudo apt-get install python3-tk, python3-pil.imagetk
+sudo apt-get install python3-tk python3-pil.imagetk
 ```
 
 > Note: The above instruction is only assured to work on Ubuntu. For


### PR DESCRIPTION
Removes the comma from ubuntu installation command which introduced errors during installation